### PR TITLE
Release pypi

### DIFF
--- a/.github/workflows/build_n_publish.yml
+++ b/.github/workflows/build_n_publish.yml
@@ -1,0 +1,41 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on: push
+
+
+jobs:
+  build-n-publish:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/dalec-gitlab
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish package distributions to yPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author = Webu
 author_email = contact@webu.coop
 description = Dalec plugin to retrieve gitlab issues, events or milestone
 long_description = file: README.md
+long_description_content_type = text/markdown
 license = BSD-3-Clause
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Automatic release to pypi on tag push (test.pypi.org right now). To be updated